### PR TITLE
Update module-vault dependency to version 100.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "adyen/php-api-library": "*",
     "magento/framework": ">=100.1.0",
-    "magento/module-vault": "100.1.*"
+    "magento/module-vault": "100.1.*|100.2.*"
   },
   "autoload": {
     "files": [


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
In Magento 2.1.8 they added a major version upgrade to the vault: 100.2.* in order to keep compatibility with this new feature with the 2.1.* version of Magento the composer file needs to be updated.

Currently it fails with the following error on `composer update`:

	  Problem 1
	    - Installation request for adyen/module-payment dev-feature/vault -> satisfiable by adyen/module-payment[dev-feature/vault].
	    - Conclusion: remove magento/product-community-edition 2.1.12
	    - magento/product-enterprise-edition 2.1.12 requires magento/product-community-edition 2.1.12 -> satisfiable by magento/product-community-edition[2.1.12].
	    - magento/product-enterprise-edition 2.1.12 requires magento/product-community-edition 2.1.12 -> satisfiable by magento/product-community-edition[2.1.12].
	    - Conclusion: don't install magento/product-community-edition 2.1.12
	    - Installation request for magento/product-enterprise-edition 2.1.12 -> satisfiable by magento/product-enterprise-edition[2.1.12].

**Tested scenarios**
<!-- Description of tested scenarios -->
Composer installed successfully from `dev-vault-version-fix` fork branch:

	  - Updating adyen/module-payment (dev-master 787f9f5 => dev-vault-version-fix 73cab08)
	    Checking out 73cab0812df6e4eaba4c8f0d5bf0b07af1047851

**Fixed issue**:  
Relates to #252 Register a new Vault entry when processing a RECURRING_CONTRACT notification (for CC)